### PR TITLE
Add "main" section to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,9 @@
   "dependencies": {
     "jquery": ">=1.3"
   },
+  "main": [
+    "./dist/jquery.livequery"
+  ],
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
This section defines the entry point for using this library. https://github.com/bower/spec/blob/master/json.md#main

I'm primarily interested in adding it for better integration with rails-assets.org (a bower-bundler bridge).
